### PR TITLE
Fix for invalid JSON (Expected: 'EOF')

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -207,5 +207,4 @@
         "yotpo/magento2-module-yotpo-reviews": "*",
         "yotpo/magento2-module-yotpo-reviews-bundle": "*"
     }
-  }
 }


### PR DESCRIPTION
Covering #10 Issue, this should make it possible to use the package on Magento 2.3.5 without errors.