### PR TITLE
Fix bug 'Class Magento\ReleaseNotification\Model\Condition\CanViewNotification does not exist' when running setup:di:complile on Magento 2.3.4 sample data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,7 @@
         "magento/module-quote-analytics": "*",
         "magento/module-quote-graph-ql": "*",
         "magento/module-related-product-graph-ql": "*",
+        "magento/module-admin-analytics" : "*",
         "magento/module-release-notification": "*",
         "magento/module-review-analytics": "*",
         "magento/module-review-staging": "*",


### PR DESCRIPTION
Here is the screenshot showing the error: https://prnt.sc/snvu7b