### PR TITLE
Fix Fatal Error: 'Uncaught Error: Cannot instantiate interface Magento\Framework\MessageQueue\ConfigInterface in ...' when accessing the checkout page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,6 @@
         "magento/module-inventory-source-selection-api": "*",
         "magento/module-layered-navigation-staging": "*",
         "magento/module-marketplace": "*",
-        "magento/module-message-queue": "*",
         "magento/module-msrp-staging": "*",
         "magento/module-multishipping": "*",
         "magento/module-mysql-mq": "*",


### PR DESCRIPTION
I got the same message queue issue as Andreas mentioned his [post](https://www.integer-net.com/make-magento-2-small-again/) when accessing the checkout page on Magento 2.3.4 CE

Here is the error log: 
`"Fatal Error: 'Uncaught Error: Cannot instantiate interface Magento\\Framework\\MessageQueue\\ConfigInterface in \/Applications\/MAMP\/htdocs\/performance-optimization\/vendor\/magento\/framework\/ObjectManager\/Factory\/AbstractFactory.php:121\nStack trace:\n#0 \/Applications\/MAMP\/htdocs\/performance-optimization\/vendor\/magento\/framework\/ObjectManager\/Factory\/Compiled.php(108): Magento\\Framework\\ObjectManager\\Factory\\AbstractFactory->createObject('Magento\\\\Framewo...', Array)\n#1 \/Applications\/MAMP\/htdocs\/performance-optimization\/vendor\/magento\/framework\/ObjectManager\/Factory\/Compiled.php(150): Magento\\Framework\\ObjectManager\\Factory\\Compiled->create('Magento\\\\Framewo...')\n#2 \/Applications\/MAMP\/htdocs\/performance-optimization\/vendor\/magento\/framework\/ObjectManager\/Factory\/Compiled.php(79): Magento\\Framework\\ObjectManager\\Factory\\Compiled->get('Magento\\\\Framewo...')\n#3 \/Applications\/MAMP\/htdocs\/performance-optimization\/vendor\/magento\/framework\/ObjectManager\/Factory\/Compiled.php(150): Magento\\Framework\\ObjectManager\\Factory\\Compiled->create('' in '\/Applications\/MAMP\/htdocs\/performance-optimization\/vendor\/magento\/framework\/ObjectManager\/Factory\/AbstractFactory.php' on line 121"`

The reason the error occurs is that the di preference setting for Magento\\Framework\\MessageQueue\\ConfigInterface is missing. 

This PR adds the module that contains the di preference setting to bypass the error.